### PR TITLE
Add display names for characters

### DIFF
--- a/LoveDialogue/LoveDialogue.lua
+++ b/LoveDialogue/LoveDialogue.lua
@@ -517,10 +517,11 @@ end
 function LoveDialogue:drawName(x, y, opacity)
     if self.state.currentCharacter == "" then return end
     local char = self.state.characters[self.state.currentCharacter]
+    local dName = char and char.dName or self.state.currentCharacter
     local c = char and char.nameColor or self.config.nameColor
     love.graphics.setFont(self.resources.nameFont)
     love.graphics.setColor(c[1] or c.r, c[2] or c.g, c[3] or c.b, opacity)
-    love.graphics.print(self.state.currentCharacter, x, y)
+    love.graphics.print(dName, x, y)
 end
 
 function LoveDialogue:drawChoices(x, y, textLimit, opacity)

--- a/LoveDialogue/LoveDialogueParser.lua
+++ b/LoveDialogue/LoveDialogueParser.lua
@@ -52,9 +52,15 @@ function Parser.parseFile(path, instanceId)
         local clean = line:match("^%s*(.-)%s*$")
         if clean ~= "" and not clean:match("^//") then
             
-            -- 1. Portraits
+            -- 1. Characters and Portraits
+            local cName, dName = clean:match('^@character%s+(%S+)%s+"([^"]+)"%s*$')
             local pName, pPath = clean:match('^@portrait%s+(%S+)%s+(.+)$')
-            if pName then
+            if cName then
+                if not chars[cName] then
+                    chars[cName] = Character.new(cName, instanceId)
+                end
+                chars[cName].dName = dName
+            elseif pName then
                 if not chars[pName] then chars[pName] = Character.new(pName, instanceId) end
                 chars[pName]:loadExpression("Default", pPath, 1, 1, 1)
             elseif clean:match('^@sheet%s+') then

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,26 +36,32 @@ When calling `LoveDialogue.play(file, config)`, you can pass a table with the fo
 
 Scripts are plain text files. Lines starting with `//` are comments.
 
-### 1. Defining Portraits
-At the very top of your file:
+### 1. Characters
+If the name of the character contains spaces you can define their display name with **@character**. At the very top of the file:
+```ini
+@character CharacterName "Display Name"
+```
+
+### 2. Defining Portraits
+Just below **@character**:
 ```ini
 @portrait CharacterName path/to/image.png
 ```
 
-### 2. Labels (Scenes)
+### 3. Labels (Scenes)
 Labels mark the start of a section. You can jump to them using choices.
 ```ini
 [my_scene_name]
 ```
 
-### 3. Dialogue
+### 4. Dialogue
 Format: `Name: Text`
 ```ini
 Alice: Hi there!
 Bob: (Happy) Hello Alice!
 ```
 
-### 4. Logic & Variables
+### 5. Logic & Variables
 Set variables with `$`:
 ```ini
 $ coins = 100
@@ -71,7 +77,7 @@ Branch flow with `[if]`:
 [endif]
 ```
 
-### 5. Signals
+### 6. Signals
 Trigger external game events (handled via `dialogue.onSignal` in Lua).
 ```ini
 [signal: CameraShake 5]


### PR DESCRIPTION
Adds support for declaring a separate display name for a character while continuing to use a whitespace-free identifier internally.

Example:

@character JohnDoe "John Doe"

JohnDoe: Hello world!

I added this because otherwise there is no way to have a character with a name which contains spaces. If the display name is not defined then it just displays the identifier name.