### PR TITLE
Add [goto:scene_label]

### DIFF
--- a/LoveDialogue/LoveDialogue.lua
+++ b/LoveDialogue/LoveDialogue.lua
@@ -266,6 +266,14 @@ function LoveDialogue:processCurrentLine()
         self:loadTheme(line.path)
         self.state.currentLineIndex = self.state.currentLineIndex + 1
         return self:processCurrentLine()
+
+    elseif line.type == "goto" then
+        local targetIndex = self.state.scenes[line.target]
+        if not targetIndex then
+            error("Unknown dialogue label: " .. tostring(line.target))
+        end
+        self.state.currentLineIndex = targetIndex
+        return self:processCurrentLine()
         
     elseif line.type == "move" then
         local char = self.state.characters[line.name]

--- a/LoveDialogue/LoveDialogueParser.lua
+++ b/LoveDialogue/LoveDialogueParser.lua
@@ -154,6 +154,17 @@ function Parser.parseFile(path, instanceId)
             elseif clean:match('^%[load_theme:.+%]$') then
                 local themePath = clean:match('^%[load_theme:%s*(.+)%]$')
                 table.insert(lines, { type = "theme_load", path = themePath })
+            -- Goto
+            elseif clean:match('^%[goto:.+%]$') then
+                local target = clean:match('^%[goto:%s*([%w_%-]+)%s*%]$')
+                if target then
+                    table.insert(lines, {
+                        type = "goto",
+                        target = target
+                    })
+                else
+                    print("Warning: Failed to parse goto: '" .. clean .. "'")
+                end
             -- Labels
             elseif clean:match('^%[.*%]$') then
                 local sName = clean:match('^%[(.*)%]$')

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,24 @@ Choices appear at the end of a dialogue block.
 -> Option Text [target:label_name] [if: condition]
 ```
 
+### 7. Goto
+You can also jump to labels using **goto**.
+```ini
+-> Option Text 1 [target:choice1]
+-> Option Text 2 [target:choice2]
+
+[choice1]
+    Alice: First line of dialogue
+    [goto:choices_end]
+
+[choice2]
+    Alice: Second line of dialogue
+    [goto:choices_end]
+
+[choices_end]
+Alice: Third line of dialogue
+```
+
 ---
 
 ## Text Effects


### PR DESCRIPTION
I added **goto** because currently when lines in a choice ends, lines in the next choice begin much like in a switch statement without break.