### PR TITLE
Automate tagged GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Build release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+
+          zip -r dist/LoveDialogue.zip LoveDialogue
+
+          cd tools
+          zip -r ../dist/ld-nvim.zip ld-nvim
+          cd ld-vscode
+          npx --yes @vscode/vsce@3 package --out ../../dist/ld-vscode.vsix
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          files: |
+            dist/LoveDialogue.zip
+            dist/ld-nvim.zip
+            dist/ld-vscode.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - "**"
 
 permissions:
   contents: write
@@ -36,12 +36,15 @@ jobs:
           cd ld-vscode
           npx --yes @vscode/vsce@3 package --out ../../dist/ld-vscode.vsix
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          fail_on_unmatched_files: true
-          generate_release_notes: true
-          files: |
-            dist/LoveDialogue.zip
-            dist/ld-nvim.zip
-            dist/ld-vscode.vsix
+      - name: Publish release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$RELEASE_TAG" \
+            dist/LoveDialogue.zip \
+            dist/ld-nvim.zip \
+            dist/ld-vscode.vsix \
+            --verify-tag \
+            --title "$RELEASE_TAG" \
+            --generate-notes

--- a/tools/ld-vscode/.vscodeignore
+++ b/tools/ld-vscode/.vscodeignore
@@ -1,0 +1,4 @@
+.gitignore
+.vscodeignore
+*.vsix
+node_modules/


### PR DESCRIPTION
## Summary

Adds an automated GitHub release workflow for LoveDialogue.

## Creating a release

After this change is merged, a maintainer can create a release by pushing a new Git tag:

```bash
git checkout main
git pull
git tag v1.2.3
git push origin v1.2.3
```

The workflow automatically creates a GitHub Release for the tag, generates release notes, and attaches:

- `LoveDialogue.zip` — LoveDialogue library
- `ld-nvim.zip` — Neovim extension
- `ld-vscode.vsix` — Visual Studio Code extension

If an expected asset cannot be built, the release job fails instead of publishing an incomplete release.